### PR TITLE
edge - fix dac point formatting in hud

### DIFF
--- a/edge.cfg
+++ b/edge.cfg
@@ -1,10 +1,10 @@
 // Edge by Ricky Thomson (maps/edge)
 // The shady backstreets at the edge of the city, where crime and corporate interests tangle together.
 
-point_4 = [ Central Square ]
-point_2 = [ Alpha Base     ]
-point_3 = [ Loading Bay    ]
-point_1 = [ Omega Base     ]
+point_4 = [Central Square]
+point_2 = [Alpha Base]
+point_3 = [Loading Bay]
+point_1 = [Omega Base]
 
 texture water "nieb/water.png"
 texture 1 "appleflap/snow_nm.jpg"


### PR DESCRIPTION
Fixes the text wrapping on the hud for dac point names.
