### PR TITLE
edge - fix trak5 pipez texture slot

### DIFF
--- a/edge.cfg
+++ b/edge.cfg
@@ -212,7 +212,7 @@ setshader bumpspecmapparallaxworld
 setshaderparam specscale 0.500000 0.500000 0.500000 0.000000
 texture 0 "trak/trak5/pipez1a.jpg" // 22
 texture n "trak/trak5/pipez1_n.png"
-texture z "trak/trak5/pipez1_s.jpg"
+texture s "trak/trak5/pipez1a_s.jpg"
 texscale 0.25
 
 setshader bumpspecmapparallaxworld


### PR DESCRIPTION
Fixes wrong texture path / type for specmap;

See; https://github.com/redeclipse/trak/pull/3
